### PR TITLE
Set the url, baseurl, and email.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,12 +1,12 @@
 # Site settings
 title: mathblogging.org
-email: your-email@domain.com
+email: mathblogging.network@gmail.com
 description: > # this means to ignore newlines until "baseurl:"
   Write an awesome description for your new site here. You can edit this
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
-baseurl: "" # the subpath of your site, e.g. /blog
-url: "http://yourdomain.com" # the base hostname & protocol for your site
+baseurl: "/" # the subpath of your site, e.g. /blog
+url: "http://mathblogging.org" # the base hostname & protocol for your site
 twitter_username: jekyllrb
 github_username:  jekyll
 


### PR DESCRIPTION
Because you don't want HTML `<meta>` things to have the wrong URL.
And you might as well set the correct email.